### PR TITLE
fix: uncaught exception when publishing reaction/repost

### DIFF
--- a/src/components/event/textNote/TextNoteDisplay.tsx
+++ b/src/components/event/textNote/TextNoteDisplay.tsx
@@ -138,7 +138,9 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
   const publishReactionMutation = createMutation({
     mutationKey: ['publishReaction', event().id],
     mutationFn: (...params: Parameters<typeof commands.publishReaction>) =>
-      commands.publishReaction(...params).then((promeses) => Promise.allSettled(promeses.map(timeout(10000)))),
+      commands
+        .publishReaction(...params)
+        .then((promeses) => Promise.allSettled(promeses.map(timeout(5000)))),
     onSuccess: (results) => {
       const succeeded = results.filter((res) => res.status === 'fulfilled').length;
       const failed = results.length - succeeded;
@@ -163,7 +165,9 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
   const publishRepostMutation = createMutation({
     mutationKey: ['publishRepost', event().id],
     mutationFn: (...params: Parameters<typeof commands.publishRepost>) =>
-      commands.publishRepost(...params).then((promeses) => Promise.allSettled(promeses.map(timeout(10000)))),
+      commands
+        .publishRepost(...params)
+        .then((promeses) => Promise.allSettled(promeses.map(timeout(10000)))),
     onSuccess: (results) => {
       const succeeded = results.filter((res) => res.status === 'fulfilled').length;
       const failed = results.length - succeeded;

--- a/src/components/event/textNote/TextNoteDisplay.tsx
+++ b/src/components/event/textNote/TextNoteDisplay.tsx
@@ -137,9 +137,18 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
 
   const publishReactionMutation = createMutation({
     mutationKey: ['publishReaction', event().id],
-    mutationFn: commands.publishReaction.bind(commands),
-    onSuccess: () => {
-      console.log('succeeded to publish reaction');
+    mutationFn: (...params: Parameters<typeof commands.publishReaction>) =>
+      commands.publishReaction(...params).then((promeses) => Promise.allSettled(promeses.map(timeout(10000)))),
+    onSuccess: (results) => {
+      const succeeded = results.filter((res) => res.status === 'fulfilled').length;
+      const failed = results.length - succeeded;
+      if (succeeded === results.length) {
+        console.log('succeeded to publish reaction');
+      } else if (succeeded > 0) {
+        console.log('failed to publish reaction on ${failed} nodes');
+      } else {
+        console.error('failed to publish reaction on all node');
+      }
     },
     onError: (err) => {
       console.error('failed to publish reaction: ', err);
@@ -153,9 +162,18 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
 
   const publishRepostMutation = createMutation({
     mutationKey: ['publishRepost', event().id],
-    mutationFn: commands.publishRepost.bind(commands),
-    onSuccess: () => {
-      console.log('succeeded to publish reposts');
+    mutationFn: (...params: Parameters<typeof commands.publishRepost>) =>
+      commands.publishRepost(...params).then((promeses) => Promise.allSettled(promeses.map(timeout(10000)))),
+    onSuccess: (results) => {
+      const succeeded = results.filter((res) => res.status === 'fulfilled').length;
+      const failed = results.length - succeeded;
+      if (succeeded === results.length) {
+        console.log('succeeded to publish reposts');
+      } else if (succeeded > 0) {
+        console.log('failed to publish reposts on ${failed} nodes');
+      } else {
+        console.error('failed to publish reposts on all node');
+      }
     },
     onError: (err) => {
       console.error('failed to publish repost: ', err);

--- a/src/components/event/textNote/TextNoteDisplay.tsx
+++ b/src/components/event/textNote/TextNoteDisplay.tsx
@@ -172,11 +172,11 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
       const succeeded = results.filter((res) => res.status === 'fulfilled').length;
       const failed = results.length - succeeded;
       if (succeeded === results.length) {
-        console.log('succeeded to publish reposts');
+        console.log('Succeeded to publish a repost');
       } else if (succeeded > 0) {
-        console.log(`failed to publish reposts on ${failed} nodes`);
+        console.warn(`Failed to publish a repost on ${failed} relays`);
       } else {
-        console.error('failed to publish reposts on all node');
+        console.error('Failed to publish a repost on all relays');
       }
     },
     onError: (err) => {

--- a/src/components/event/textNote/TextNoteDisplay.tsx
+++ b/src/components/event/textNote/TextNoteDisplay.tsx
@@ -145,7 +145,7 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
       if (succeeded === results.length) {
         console.log('succeeded to publish reaction');
       } else if (succeeded > 0) {
-        console.log('failed to publish reaction on ${failed} nodes');
+        console.log(`failed to publish reaction on ${failed} nodes`);
       } else {
         console.error('failed to publish reaction on all node');
       }
@@ -170,7 +170,7 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
       if (succeeded === results.length) {
         console.log('succeeded to publish reposts');
       } else if (succeeded > 0) {
-        console.log('failed to publish reposts on ${failed} nodes');
+        console.log(`failed to publish reposts on ${failed} nodes`);
       } else {
         console.error('failed to publish reposts on all node');
       }

--- a/src/components/event/textNote/TextNoteDisplay.tsx
+++ b/src/components/event/textNote/TextNoteDisplay.tsx
@@ -145,11 +145,11 @@ const TextNoteDisplay: Component<TextNoteDisplayProps> = (props) => {
       const succeeded = results.filter((res) => res.status === 'fulfilled').length;
       const failed = results.length - succeeded;
       if (succeeded === results.length) {
-        console.log('succeeded to publish reaction');
+        console.log('Succeeded to publish a reaction');
       } else if (succeeded > 0) {
-        console.log(`failed to publish reaction on ${failed} nodes`);
+        console.warn(`failed to publish a reaction on ${failed} relays`);
       } else {
-        console.error('failed to publish reaction on all node');
+        console.error('failed to publish reaction on all relays');
       }
     },
     onError: (err) => {

--- a/src/nostr/useCommands.ts
+++ b/src/nostr/useCommands.ts
@@ -91,7 +91,7 @@ const useCommands = () => {
   const publishEvent = async (
     relayUrls: string[],
     event: UnsignedEvent,
-  ): Promise<Promise<void>[]> => {
+  ): Promise<void> => {
     const preSignedEvent: UnsignedEvent & { id?: string } = { ...event };
     preSignedEvent.id = getEventHash(preSignedEvent);
 
@@ -100,15 +100,15 @@ const useCommands = () => {
     }
     const signedEvent = await window.nostr.signEvent(preSignedEvent);
 
-    return relayUrls.map(async (relayUrl) => {
+    return Promise.any(relayUrls.map(async (relayUrl) => {
       const relay = await pool().ensureRelay(relayUrl);
       const pub = relay.publish(signedEvent);
       return waitCommandResult(pub, relayUrl);
-    });
+    }));
   };
 
   // NIP-01
-  const publishTextNote = async (params: PublishTextNoteParams): Promise<Promise<void>[]> => {
+  const publishTextNote = async (params: PublishTextNoteParams): Promise<void>=> {
     const { relayUrls, pubkey, content } = params;
     const tags = buildTags(params);
 
@@ -135,7 +135,7 @@ const useCommands = () => {
     eventId: string;
     reactionTypes: ReactionTypes;
     notifyPubkey: string;
-  }): Promise<Promise<void>[]> => {
+  }): Promise<void>=> {
     const tags = [
       ['e', eventId, ''],
       ['p', notifyPubkey],
@@ -166,7 +166,7 @@ const useCommands = () => {
     pubkey: string;
     eventId: string;
     notifyPubkey: string;
-  }): Promise<Promise<void>[]> => {
+  }): Promise<void>=> {
     const preSignedEvent: UnsignedEvent = {
       kind: 6 as Kind,
       pubkey,
@@ -190,7 +190,7 @@ const useCommands = () => {
     pubkey: string;
     profile: Profile;
     otherProperties: Record<string, any>;
-  }): Promise<Promise<void>[]> => {
+  }): Promise<void>=> {
     const content: ProfileWithOtherProperties = {
       ...profile,
       ...otherProperties,
@@ -215,7 +215,7 @@ const useCommands = () => {
     pubkey: string;
     followingPubkeys: string[];
     content: string;
-  }): Promise<Promise<void>[]> => {
+  }): Promise<void>=> {
     const pTags = followingPubkeys.map((key) => ['p', key]);
 
     const preSignedEvent: UnsignedEvent = {
@@ -236,7 +236,7 @@ const useCommands = () => {
     relayUrls: string[];
     pubkey: string;
     eventId: string;
-  }): Promise<Promise<void>[]> => {
+  }): Promise<void>=> {
     const preSignedEvent: UnsignedEvent = {
       kind: Kind.EventDeletion,
       pubkey,

--- a/src/nostr/useCommands.ts
+++ b/src/nostr/useCommands.ts
@@ -91,7 +91,7 @@ const useCommands = () => {
   const publishEvent = async (
     relayUrls: string[],
     event: UnsignedEvent,
-  ): Promise<void> => {
+  ): Promise<Promise<void>[]> => {
     const preSignedEvent: UnsignedEvent & { id?: string } = { ...event };
     preSignedEvent.id = getEventHash(preSignedEvent);
 
@@ -100,15 +100,15 @@ const useCommands = () => {
     }
     const signedEvent = await window.nostr.signEvent(preSignedEvent);
 
-    return Promise.any(relayUrls.map(async (relayUrl) => {
+    return relayUrls.map(async (relayUrl) => {
       const relay = await pool().ensureRelay(relayUrl);
       const pub = relay.publish(signedEvent);
       return waitCommandResult(pub, relayUrl);
-    }));
+    });
   };
 
   // NIP-01
-  const publishTextNote = async (params: PublishTextNoteParams): Promise<void>=> {
+  const publishTextNote = async (params: PublishTextNoteParams): Promise<Promise<void>[]> => {
     const { relayUrls, pubkey, content } = params;
     const tags = buildTags(params);
 
@@ -135,7 +135,7 @@ const useCommands = () => {
     eventId: string;
     reactionTypes: ReactionTypes;
     notifyPubkey: string;
-  }): Promise<void>=> {
+  }): Promise<Promise<void>[]> => {
     const tags = [
       ['e', eventId, ''],
       ['p', notifyPubkey],
@@ -166,7 +166,7 @@ const useCommands = () => {
     pubkey: string;
     eventId: string;
     notifyPubkey: string;
-  }): Promise<void>=> {
+  }): Promise<Promise<void>[]> => {
     const preSignedEvent: UnsignedEvent = {
       kind: 6 as Kind,
       pubkey,
@@ -190,7 +190,7 @@ const useCommands = () => {
     pubkey: string;
     profile: Profile;
     otherProperties: Record<string, any>;
-  }): Promise<void>=> {
+  }): Promise<Promise<void>[]> => {
     const content: ProfileWithOtherProperties = {
       ...profile,
       ...otherProperties,
@@ -215,7 +215,7 @@ const useCommands = () => {
     pubkey: string;
     followingPubkeys: string[];
     content: string;
-  }): Promise<void>=> {
+  }): Promise<Promise<void>[]> => {
     const pTags = followingPubkeys.map((key) => ['p', key]);
 
     const preSignedEvent: UnsignedEvent = {
@@ -236,7 +236,7 @@ const useCommands = () => {
     relayUrls: string[];
     pubkey: string;
     eventId: string;
-  }): Promise<void>=> {
+  }): Promise<Promise<void>[]> => {
     const preSignedEvent: UnsignedEvent = {
       kind: Kind.EventDeletion,
       pubkey,


### PR DESCRIPTION
Promise<Promise<void>[]>だとPromiseの配列なので,どれかが失敗すると
```log
Uncaught (in promise) blocked: no active subscription
```
となるのでPromise.anyでどれかのrelayに発信できたらそれでOKとしました
これが発生するとちらつくみたいなのでホワイトアウト現象の解決の一助になるといいなと思います