### PR TITLE
fix: Some npm-scripts cannot run on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "watch-test": "vitest --watch",
     "cover": "vitest run --coverage",
     "prepare": "husky install",
-    "generatePackageInfo": "node -e 'import(\"./scripts/generatePackageInfo.mjs\").then((m) => m.default())'",
-    "checkLicense": "node -e 'import(\"./scripts/checkLicense.mjs\").then((m) => m.default())'",
-    "checkSecrets": "node -e 'import(\"./scripts/checkSecrets.mjs\").then((m) => m.default())'"
+    "generatePackageInfo": "node -e \"import('./scripts/generatePackageInfo.mjs').then((m) => m.default())\"",
+    "checkLicense": "node -e \"import('./scripts/checkLicense.mjs').then((m) => m.default())\"",
+    "checkSecrets": "node -e \"import('./scripts/checkSecrets.mjs').then((m) => m.default())\""
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.61.0",


### PR DESCRIPTION
Windowsで起動(npm run dev)すると、`generatePackageInfo.mjs`を実行することができずエラーとなり、`m.default())'`という謎のファイルが出現します。

npm-scriptsの引用符やエスケープを変更することでWindowsでも起動できるようになります。

npm run buildをWindows(コマンドプロンプト)とLinux(Dockerイメージ: node:18)で動作させた結果をスクリーンショットしました。MacOSは持っていないので試せていませんが通るはずです。

| OS | Before | After |
| ---- | ---- | ---- |
| Windows | ![2023-07-27_11h35_06](https://github.com/syusui-s/rabbit/assets/4381346/aff45343-cb20-42c7-9d60-4088b870dd89) | ![2023-07-27_11h38_21](https://github.com/syusui-s/rabbit/assets/4381346/17fe183c-8973-47f6-8b83-7e20ccedf170) |
| Docker image node:18 (Debianベース) | ![2023-07-27_12h05_11](https://github.com/syusui-s/rabbit/assets/4381346/c8798919-1751-48c1-978d-1d5e630980af) | ![2023-07-27_12h06_37](https://github.com/syusui-s/rabbit/assets/4381346/c35e3ccd-6d63-49ea-9c65-3c820d0499bc) |