### PR TITLE
fix: preserve non-p-tags when updating contact list

### DIFF
--- a/src/nostr/useCommands.ts
+++ b/src/nostr/useCommands.ts
@@ -208,21 +208,19 @@ const useCommands = () => {
   const updateContacts = async ({
     relayUrls,
     pubkey,
-    followingPubkeys,
+    updatedTags,
     content,
   }: {
     relayUrls: string[];
     pubkey: string;
-    followingPubkeys: string[];
+    updatedTags: string[][];
     content: string;
   }): Promise<Promise<void>[]> => {
-    const pTags = followingPubkeys.map((key) => ['p', key]);
-
     const preSignedEvent: UnsignedEvent = {
       kind: Kind.Contacts,
       pubkey,
       created_at: epoch(),
-      tags: pTags,
+      tags: updatedTags,
       content,
     };
     return publishEvent(relayUrls, preSignedEvent);


### PR DESCRIPTION
Amethyst uses `e`-tags in a contact list(kind:3) to "follow" public chat rooms(NIP-28). However, under Rabbit's current implementation, all non-`p`-tags are removed when updating a contact list.  As a result, Amethyst's follow list of chat rooms will be destroyed.

This PR should fix it.
