### PR TITLE
feat: prevent appendText from inserting unnecessary whitespace

### DIFF
--- a/src/components/NotePostForm.tsx
+++ b/src/components/NotePostForm.tsx
@@ -91,7 +91,7 @@ const NotePostForm: Component<NotePostFormProps> = (props) => {
   const [contentWarningReason, setContentWarningReason] = createSignal('');
   const [lastUsedHashTags, setLastUsedHashTags] = createSignal<string[]>([]);
 
-  const appendText = (s: string) => setText((current) => `${current} ${s}`);
+  const appendText = (s: string) => setText((current) => (current === '' ? s : `${current} ${s}`));
 
   const resetText = () => {
     setText(


### PR DESCRIPTION
編集中のノートに絵文字や画像が追加されるとき、もとのテキストが空ならばスペースを挿入しないようにします。この変更は絵文字や画像をそれ単体で投稿するユースケースを想定しています。