### PR TITLE
feat: enable autofocus of EmojiPicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head prefix="og: http://ogp.me/ns# website: http://ogp.me/ns/website#">
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <meta name="theme-color" content="#000000" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@syusui-s" />

--- a/src/components/useEmojiPicker.tsx
+++ b/src/components/useEmojiPicker.tsx
@@ -55,7 +55,7 @@ const useEmojiPicker = (propsProvider: () => UseEmojiPickerProps) => {
           emojis: customEmojis,
         },
       ],
-      autoFocus: false,
+      autoFocus: true,
       theme: 'light',
       onEmojiSelect: (emoji: EmojiData) => {
         console.log(emoji);


### PR DESCRIPTION
EmojiPicker の検索欄に自動でフォーカスが当たると便利だと感じました。

もとのコードでは明示的に `autoFocus: false` とされていたので、方針に反するようなら本件は遠慮なくクローズしてください。あるいはユーザオプションに `autoFocus` を制御するフラグを加える方針が許されるならば、仰ってくれれば変更を加えます。