### PR TITLE
feat: allow hyphens in custom emoji

### DIFF
--- a/src/components/modal/config/emoji/EmojiSection.tsx
+++ b/src/components/modal/config/emoji/EmojiSection.tsx
@@ -33,7 +33,7 @@ const EmojiSection = () => {
             name="shortcode"
             placeholder="smiley"
             value={shortcodeInput()}
-            pattern="^\\w+$"
+            pattern="^[\\w-]+$"
             required
             onChange={(ev) => setShortcodeInput(ev.currentTarget.value)}
           />

--- a/src/hooks/useEmojiComplete.tsx
+++ b/src/hooks/useEmojiComplete.tsx
@@ -20,7 +20,7 @@ const useEmojiComplete = () => {
       [
         {
           id: 'customEmoji',
-          match: /\B:(\w+)$/,
+          match: /\B:([\w-]+)$/,
           search: (term, callback) => {
             callback(searchEmojis(term));
           },

--- a/src/nostr/event/Reaction.ts
+++ b/src/nostr/event/Reaction.ts
@@ -4,7 +4,7 @@ import { type Event as NostrEvent } from 'nostr-tools/pure';
 import GenericEvent from '@/nostr/event/GenericEvent';
 
 const emojiRegex = /^\p{Emoji}[\p{Emoji_Component}\p{Emoji_Modifier}\p{Emoji_Presentation}]*$/u;
-const customEmojiRegex = /^:(\w+):$/;
+const customEmojiRegex = /^:([\w-]+):$/;
 
 export type ReactionTypes =
   | { type: 'Emoji'; content: string }

--- a/src/nostr/event/TagsBase.ts
+++ b/src/nostr/event/TagsBase.ts
@@ -9,8 +9,8 @@ export const TagsSchema = z.array(z.array(z.string()));
 export const EmojiTagSchema = z
   .tuple([
     z.literal('emoji'),
-    z.string().regex(/^\w+$/, {
-      message: 'shortcode can includes only alpahnumeric characters and underscore',
+    z.string().regex(/^[\w-]+$/, {
+      message: 'shortcode can include only alphanumeric characters, underscores and hyphens',
     }),
     z.string().url(),
   ])

--- a/src/nostr/parseTextNote.test.ts
+++ b/src/nostr/parseTextNote.test.ts
@@ -279,6 +279,10 @@ describe('parseTextNote', () => {
       expected: [{ type: 'CustomEmoji', content: ':bunhd:', shortcode: 'bunhd' }],
     },
     {
+      given: ':bunhd-pop:',
+      expected: [{ type: 'CustomEmoji', content: ':bunhd-pop:', shortcode: 'bunhd-pop' }],
+    },
+    {
       given: ':sushi_maguro:',
       expected: [{ type: 'CustomEmoji', content: ':sushi_maguro:', shortcode: 'sushi_maguro' }],
     },
@@ -302,7 +306,7 @@ describe('parseTextNote', () => {
     assert.deepStrictEqual(parsed, expected);
   });
 
-  it.each([':bunhd-hop:', ':+1:', ':-1:', ':hello', '::: NOSTR :::'])(
+  it.each([':+1:', ':hello', '::: NOSTR :::'])(
     'should parse text note which includes invalid custom emoji ($emoji)',
     (content) => {
       const parsed = parseTextNote(content);

--- a/src/nostr/parseTextNote.ts
+++ b/src/nostr/parseTextNote.ts
@@ -93,7 +93,7 @@ const tagRefRegex = /(?:#\[(?<idx>\d+)\])/g;
 const mentionRegex =
   /(?<mention>(?<nip19>nostr:)?(?<bech32>(?:npub|note|nprofile|nevent|naddr)1[ac-hj-np-z02-9]+))/gi;
 const hashTagRegex = /#(?<hashtag>[\p{Letter}\p{Number}_]+)/gu;
-const customEmojiRegex = /:(?<emoji>\w+):/gu;
+const customEmojiRegex = /:(?<emoji>[\w-]+):/gu;
 
 const parseTextNote = (textNoteContent: string) => {
   const matches = [

--- a/src/utils/emojipack.ts
+++ b/src/utils/emojipack.ts
@@ -34,7 +34,7 @@ export const pubkeySchema = z
   .length(64)
   .regex(/^[0-9a-f]{64}$/);
 
-export const shortcodeSchema = z.string().regex(/^\w+$/);
+export const shortcodeSchema = z.string().regex(/^[\w-]+$/);
 
 export const emojiSchema = z.object({
   shortcode: shortcodeSchema,


### PR DESCRIPTION
This PR is allows hyphens in custom emoji shortcodes. It is following NIP-30 update: https://github.com/nostr-protocol/nips/commit/d004b4cb4874ca40119aa219b0438d835f712d8d

# Before 
<img width="210" height="100" alt="2026-04-30T23:22:38,596632119+09:00" src="https://github.com/user-attachments/assets/d6da356c-081d-4bcf-b588-2719aa1873ed" />

# After
<img width="162" height="99" alt="2026-04-30T23:22:51,713149431+09:00" src="https://github.com/user-attachments/assets/a3e5255b-3be7-4c4c-80ef-747bd6f033bf" />



I trimmed down the test cases a bit, but is that okay?