### PR TITLE
feat: support Blossom file servers for media upload

### DIFF
--- a/src/components/modal/config/posting/FileServerSection.tsx
+++ b/src/components/modal/config/posting/FileServerSection.tsx
@@ -16,17 +16,19 @@ const FileServerSection = () => {
   const { config, setFileServer, addCustomFileServer, removeCustomFileServer } = useConfig();
 
   const [urlInput, setUrlInput] = createSignal('');
+  const [typeInput, setTypeInput] = createSignal<FileServerDefinition['type']>('nip96');
 
   const handleSubmit: JSX.EventHandler<HTMLFormElement, SubmitEvent> = (ev) => {
     ev.preventDefault();
 
     addCustomFileServer({
-      type: 'nip96',
+      type: typeInput(),
       name: urlInput(),
       serverUrl: urlInput(),
     });
 
     ev.currentTarget.reset();
+    setTypeInput('nip96');
   };
 
   const servers = (): FileServerDefinitionCustom[] => [
@@ -52,10 +54,16 @@ const FileServerSection = () => {
               >
                 <button
                   type="button"
-                  class="flex-1 text-start"
+                  class="flex flex-1 items-center gap-2 text-start"
                   onClick={() => setFileServer(server)}
                 >
-                  {server.name}
+                  <span class="flex-1">{server.name}</span>
+                  <span
+                    class="rounded-sm border border-current px-1 text-xs opacity-70"
+                    classList={{ 'text-primary-fg': isDefault() }}
+                  >
+                    {server.type === 'blossom' ? 'Blossom' : 'NIP-96'}
+                  </span>
                 </button>
                 <Show when={server.custom}>
                   <button type="button" onClick={() => removeCustomFileServer(server.name)}>
@@ -70,6 +78,15 @@ const FileServerSection = () => {
         </For>
       </div>
       <form class="mt-2 flex gap-2" onSubmit={handleSubmit}>
+        <select
+          class="rounded-md border border-border bg-bg ring-border focus:border-border focus:ring-primary"
+          name="type"
+          value={typeInput()}
+          onChange={(ev) => setTypeInput(ev.currentTarget.value as FileServerDefinition['type'])}
+        >
+          <option value="nip96">NIP-96</option>
+          <option value="blossom">Blossom</option>
+        </select>
         <input
           class="flex-1 rounded-md border border-border bg-bg ring-border placeholder:text-fg-secondary focus:border-border focus:ring-primary"
           type="text"

--- a/src/utils/imageUpload.test.ts
+++ b/src/utils/imageUpload.test.ts
@@ -1,0 +1,90 @@
+import assert from 'assert';
+
+import { describe, it } from 'vitest';
+
+import {
+  blossomDescriptorToFileUploadResponse,
+  fileUploadResponseToImetaTag,
+  type BlossomBlobDescriptor,
+} from '@/utils/imageUpload';
+
+describe('blossomDescriptorToFileUploadResponse', () => {
+  it('synthesizes nip94 tags from a blob descriptor', () => {
+    const descriptor: BlossomBlobDescriptor = {
+      url: 'https://blossom.example/abc.png',
+      sha256: 'abc',
+      size: 1234,
+      type: 'image/png',
+      uploaded: 1700000000,
+    };
+
+    const actual = blossomDescriptorToFileUploadResponse(descriptor);
+
+    assert.equal(actual.status, 'success');
+    assert.deepStrictEqual(actual.nip94_event?.tags, [
+      ['url', 'https://blossom.example/abc.png'],
+      ['x', 'abc'],
+      ['ox', 'abc'],
+      ['size', '1234'],
+      ['m', 'image/png'],
+    ]);
+  });
+
+  it('omits size and mime tags when they are absent', () => {
+    const descriptor = {
+      url: 'https://blossom.example/abc',
+      sha256: 'abc',
+    } as BlossomBlobDescriptor;
+
+    const actual = blossomDescriptorToFileUploadResponse(descriptor);
+
+    assert.deepStrictEqual(actual.nip94_event?.tags, [
+      ['url', 'https://blossom.example/abc'],
+      ['x', 'abc'],
+      ['ox', 'abc'],
+    ]);
+  });
+
+  it('prefers the server-provided nip94 tags (BUD-08) when present', () => {
+    const descriptor: BlossomBlobDescriptor = {
+      url: 'https://blossom.example/abc.png',
+      sha256: 'abc',
+      size: 1234,
+      type: 'image/png',
+      nip94: [
+        ['url', 'https://blossom.example/resized.png'],
+        ['m', 'image/png'],
+        ['dim', '640x480'],
+      ],
+    };
+
+    const actual = blossomDescriptorToFileUploadResponse(descriptor);
+
+    assert.deepStrictEqual(actual.nip94_event?.tags, [
+      ['url', 'https://blossom.example/resized.png'],
+      ['m', 'image/png'],
+      ['dim', '640x480'],
+    ]);
+  });
+
+  it('produces an imeta tag usable by the upload pipeline', () => {
+    const descriptor: BlossomBlobDescriptor = {
+      url: 'https://blossom.example/abc.png',
+      sha256: 'abc',
+      size: 1234,
+      type: 'image/png',
+    };
+
+    const response = blossomDescriptorToFileUploadResponse(descriptor);
+    const imetaTag = fileUploadResponseToImetaTag(response);
+
+    assert.deepStrictEqual(imetaTag, [
+      'imeta',
+      'url https://blossom.example/abc.png',
+      'x abc',
+      'ox abc',
+      'size 1234',
+      'm image/png',
+    ]);
+  });
+});

--- a/src/utils/imageUpload.ts
+++ b/src/utils/imageUpload.ts
@@ -9,11 +9,18 @@ import { z } from 'zod';
 
 import sleep from '@/utils/sleep';
 
-export const FileServerDefinitionScheme = z.object({
-  type: z.literal('nip96'),
-  name: z.string(),
-  serverUrl: z.string().url(),
-});
+export const FileServerDefinitionScheme = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('nip96'),
+    name: z.string(),
+    serverUrl: z.string().url(),
+  }),
+  z.object({
+    type: z.literal('blossom'),
+    name: z.string(),
+    serverUrl: z.string().url(),
+  }),
+]);
 
 export type FileServerDefinition = z.infer<typeof FileServerDefinitionScheme>;
 
@@ -58,6 +65,21 @@ export const defaultFileServers = [
     type: 'nip96',
     name: 'yabu.me',
     serverUrl: 'https://yabu.me/',
+  },
+  {
+    type: 'blossom',
+    name: 'blossom.primal.net',
+    serverUrl: 'https://blossom.primal.net/',
+  },
+  {
+    type: 'blossom',
+    name: 'cdn.satellite.earth',
+    serverUrl: 'https://cdn.satellite.earth/',
+  },
+  {
+    type: 'blossom',
+    name: 'blossom.band',
+    serverUrl: 'https://blossom.band/',
   },
 ] satisfies FileServerDefinition[];
 
@@ -169,7 +191,7 @@ const buildApiUrl = (apiUrl: string, serverUrl: string): string => {
   return apiUrl;
 };
 
-export const uploadFileStorage = async ({
+export const uploadFileStorageNip96 = async ({
   serverUrl,
   files,
 }: UploadFileStorageParams): Promise<PromiseSettledResult<FileUploadResponse>[]> => {
@@ -184,5 +206,105 @@ export const uploadFileStorage = async ({
   return Promise.allSettled(promises);
 };
 
-export const upload = (server: FileServerDefinition) => (files: File[]) =>
-  uploadFileStorage({ files, serverUrl: server.serverUrl });
+// Blossom (BUD-01/BUD-02/BUD-08)
+
+const sha256Hex = async (file: File): Promise<string> => {
+  const buffer = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+// BUD-01 authorization event (kind 24242), base64-encoded into a `Nostr` scheme header.
+export const getBlossomAuthorizationHeader = async (sha256: string): Promise<string> => {
+  const windowNostr = window.nostr;
+  if (windowNostr == null) throw new Error('NIP-07 implementation not found');
+
+  const now = Math.floor(Date.now() / 1000);
+  const event = await windowNostr.signEvent({
+    kind: 24242,
+    content: 'Upload file',
+    created_at: now,
+    tags: [
+      ['t', 'upload'],
+      ['x', sha256],
+      ['expiration', (now + 60 * 5).toString(10)],
+    ],
+  });
+
+  return `Nostr ${btoa(JSON.stringify(event))}`;
+};
+
+export type BlossomBlobDescriptor = {
+  url: string;
+  sha256: string;
+  size: number;
+  type?: string;
+  uploaded?: number;
+  // BUD-08: optional NIP-94 tags provided by the server
+  nip94?: [string, string][];
+};
+
+// Normalize a Blossom blob descriptor into the NIP-96 FileUploadResponse shape so the rest of
+// the upload pipeline (URL extraction, imeta tags) can stay protocol-agnostic.
+export const blossomDescriptorToFileUploadResponse = (
+  descriptor: BlossomBlobDescriptor,
+): FileUploadResponse => {
+  const tags: [string, string][] =
+    descriptor.nip94 != null && descriptor.nip94.length > 0
+      ? descriptor.nip94
+      : [
+          ['url', descriptor.url],
+          ['x', descriptor.sha256],
+          ['ox', descriptor.sha256],
+          ...(descriptor.size != null
+            ? ([['size', descriptor.size.toString(10)]] as [string, string][])
+            : []),
+          ...(descriptor.type != null && descriptor.type.length > 0
+            ? ([['m', descriptor.type]] as [string, string][])
+            : []),
+        ];
+
+  return {
+    status: 'success',
+    message: 'Uploaded',
+    nip94_event: { content: '', tags },
+  };
+};
+
+export const uploadBlossom = async (serverUrl: string, file: File): Promise<FileUploadResponse> => {
+  const sha256 = await sha256Hex(file);
+  const authorizationHeader = await getBlossomAuthorizationHeader(sha256);
+
+  const uploadUrl = new URL('/upload', serverUrl).toString();
+  const headers = new Headers();
+  headers.set('Authorization', authorizationHeader);
+  if (file.type.length > 0) {
+    headers.set('Content-Type', file.type);
+  }
+
+  const response = await fetch(uploadUrl, { method: 'PUT', headers, body: file });
+  if (!response.ok) {
+    const reason = response.headers.get('X-Reason') ?? response.statusText;
+    throw new Error(`failed to upload: ${reason}`);
+  }
+
+  const descriptor = (await response.json()) as BlossomBlobDescriptor;
+  return blossomDescriptorToFileUploadResponse(descriptor);
+};
+
+export const uploadFileStorageBlossom = async ({
+  serverUrl,
+  files,
+}: UploadFileStorageParams): Promise<PromiseSettledResult<FileUploadResponse>[]> => {
+  const promises = Array.from(files).map(async (file) => uploadBlossom(serverUrl, file));
+  return Promise.allSettled(promises);
+};
+
+export const upload = (server: FileServerDefinition) => (files: File[]) => {
+  if (server.type === 'blossom') {
+    return uploadFileStorageBlossom({ files, serverUrl: server.serverUrl });
+  }
+  return uploadFileStorageNip96({ files, serverUrl: server.serverUrl });
+};


### PR DESCRIPTION
Adds Blossom (BUD-01/02/08) as a second media upload protocol alongside the existing NIP-96 support.

- File server definitions become a discriminated union on `type` (`nip96` | `blossom`), and uploads are dispatched by server type.
- Blossom uploads compute the file SHA-256, sign a kind 24242 authorization event for the `Nostr` scheme header, and PUT the file to `/upload`.
- The returned blob descriptor is normalized into the existing NIP-96 `FileUploadResponse` shape, so URL extraction and imeta tag generation stay shared (prefers server-provided NIP-94 tags when available, per BUD-08).
- The config UI gains a protocol picker when adding a custom server and shows each server's protocol; a few default Blossom servers are included.
- Adds unit tests for the descriptor normalization.

Tested locally against a Blossom server with NIP-07 signing.